### PR TITLE
Use deploy resources instead of runtime nvidia

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,12 @@
 services:
   stable-diffusion-webui:
-    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
     image: emsi/stable-diffusion-webui
     build:
       context: ../


### PR DESCRIPTION
I was running into an error with the "runtime: nvidia" while using docker desktop, WSL2, and Ubuntu 22 on Windows 11 Pro.
"response from daemon: Unknown runtime specified nvidia"

This appears to be another way to define GPU access which worked in my situation and hoping it is more compatible overall.
https://docs.docker.com/compose/gpu-support/

Apologies for this being done as a PR. I would have created a simple issue instead but that option didn't appear to be available or I overlooked it. This was more to bring attention to you in case you were unaware of this definition in case you find it more suitable than "runtime: nvidia".

Appreciate the hardwork bringing docker to stable diffusion webui. I use it a lot!
